### PR TITLE
Forward subprotocol correctly to and from upstream ws

### DIFF
--- a/asgiproxy/config.py
+++ b/asgiproxy/config.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Union, Iterable
 from urllib.parse import urljoin
 
 import aiohttp
@@ -36,6 +36,12 @@ class ProxyConfig:
         """
         return headers
 
+    def get_client_protocols(self, *, scope: Scope, headers: Headers) -> Iterable[str]:
+        """
+        Get client subprotocol list so it can be passed upstream.
+        """
+        return scope.get("subprotocols", [])
+
     def process_upstream_headers(
         self, *, scope: Scope, proxy_response: aiohttp.ClientResponse
     ) -> Headerlike:
@@ -71,6 +77,7 @@ class ProxyConfig:
             method=scope.get("method", "GET"),
             url=self.get_upstream_url(scope=scope),
             headers=self.process_client_headers(scope=scope, headers=client_ws.headers),
+            protocols=self.get_client_protocols(scope=scope, headers=client_ws.headers),
         )
 
 

--- a/asgiproxy/config.py
+++ b/asgiproxy/config.py
@@ -6,7 +6,6 @@ from starlette.datastructures import Headers
 from starlette.requests import Request
 from starlette.types import Scope
 from starlette.websockets import WebSocket
-from starlette.datastructures import QueryParams
 
 Headerlike = Union[dict, Headers]
 
@@ -43,15 +42,6 @@ class ProxyConfig:
         """
         return scope.get("subprotocols", [])
 
-    def get_params(self, *, scope: Scope, headers: Headers) -> dict:
-        """
-        Get client query stream so it can be passed upstream.
-        """
-        qs = scope.get("query_string", b"")
-        if not qs:
-            return {}
-        return dict(QueryParams(qs))
-
     def process_upstream_headers(
         self, *, scope: Scope, proxy_response: aiohttp.ClientResponse
     ) -> Headerlike:
@@ -85,12 +75,9 @@ class ProxyConfig:
         """
         return dict(
             method=scope.get("method", "GET"),
-            url=self.get_upstream_url(scope=scope),
+            url=self.get_upstream_url_with_query(scope=scope),
             headers=self.process_client_headers(scope=scope, headers=client_ws.headers),
             protocols=self.get_client_protocols(scope=scope, headers=client_ws.headers),
-            params=self.get_params(
-                scope=scope, headers=client_ws.headers
-            ),
         )
 
 

--- a/asgiproxy/proxies/websocket.py
+++ b/asgiproxy/proxies/websocket.py
@@ -102,12 +102,13 @@ async def proxy_websocket(
     upstream_ws: Optional[ClientWebSocketResponse] = None
     try:
         client_ws = WebSocket(scope=scope, receive=receive, send=send)
-        await client_ws.accept()
+
         async with context.session.ws_connect(
             **context.config.get_upstream_websocket_options(
                 scope=scope, client_ws=client_ws
             )
         ) as upstream_ws:
+            await client_ws.accept(subprotocol=upstream_ws.protocol)
             ctx = WebSocketProxyContext(client_ws=client_ws, upstream_ws=upstream_ws)
             await ctx.loop()
     finally:


### PR DESCRIPTION
The proxy currently accepts the client websocket request without any `subprotocols`, even if they were sent by the client. 

This PR forwards the protocols to the upstream websocket in the connection request, and then returns the protocol that was chosen back in `accept`.