### PR TITLE
URL parameters not passed to socket

### DIFF
--- a/asgiproxy/config.py
+++ b/asgiproxy/config.py
@@ -69,7 +69,7 @@ class ProxyConfig:
         """
         return dict(
             method=scope.get("method", "GET"),
-            url=self.get_upstream_url(scope=scope),
+            url=self.get_upstream_url_with_query(scope=scope),
             headers=self.process_client_headers(scope=scope, headers=client_ws.headers),
         )
 


### PR DESCRIPTION
Websocket URLs can have query parameters. Current implrementation don't pass it. This patch replaces `get_upstream_url` with `get_upstream_url_with_query`-